### PR TITLE
feat: 가게 상세 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     implementation 'org.json:json:20231013'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/temueats/global/ex/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/temueats/global/ex/handler/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.sparta.temueats.global.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 
 import static com.sparta.temueats.global.ResponseDto.FAILURE;
 
@@ -15,7 +14,7 @@ public class GlobalExceptionHandler {
     public static final String msg = "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
 
     @ExceptionHandler(Exception.class)
-    public ResponseDto<String> handleAllExceptions(Exception ex, WebRequest request) {
+    public ResponseDto<String> handleAllExceptions(Exception ex) {
         log.error("exception: ", ex);
         return new ResponseDto<>(FAILURE, msg);
     }

--- a/src/main/java/com/sparta/temueats/global/ex/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/temueats/global/ex/handler/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.sparta.temueats.global.ex.handler;
+
+import com.sparta.temueats.global.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import static com.sparta.temueats.global.ResponseDto.FAILURE;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public static final String msg = "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+
+    @ExceptionHandler(Exception.class)
+    public ResponseDto<String> handleAllExceptions(Exception ex, WebRequest request) {
+        log.error("exception: ", ex);
+        return new ResponseDto<>(FAILURE, msg);
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/global/s3/FileController.java
+++ b/src/main/java/com/sparta/temueats/global/s3/FileController.java
@@ -1,0 +1,28 @@
+package com.sparta.temueats.global.s3;
+
+import com.sparta.temueats.global.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static com.sparta.temueats.global.ResponseDto.SUCCESS;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+@Slf4j
+public class FileController {
+
+    private final FileService fileService;
+
+    @PostMapping
+    public ResponseDto<String> uploadFile(MultipartFile file) throws IOException {
+        return new ResponseDto<>(SUCCESS, "파일 업로드 성공", fileService.uploadFile(file));
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/global/s3/FileService.java
+++ b/src/main/java/com/sparta/temueats/global/s3/FileService.java
@@ -1,0 +1,35 @@
+package com.sparta.temueats.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String fileUrl = "https://" + bucket + ".s3.amazonaws.com/" + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        amazonS3Client.putObject(bucket, fileName, file.getInputStream(), metadata);
+
+        return fileUrl;
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/global/s3/S3Config.java
+++ b/src/main/java/com/sparta/temueats/global/s3/S3Config.java
@@ -1,0 +1,33 @@
+package com.sparta.temueats.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/temueats/menu/controller/MenuController.java
@@ -6,8 +6,6 @@ import com.sparta.temueats.menu.dto.MenuCreateWithImageDto;
 import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.dto.MenuUpdateDto;
 import com.sparta.temueats.menu.service.MenuService;
-import com.sparta.temueats.store.dto.StoreReqCreateWithImageDto;
-import com.sparta.temueats.store.dto.StoreReqResDto;
 import com.sparta.temueats.store.util.ValidUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;

--- a/src/main/java/com/sparta/temueats/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/temueats/menu/controller/MenuController.java
@@ -2,9 +2,12 @@ package com.sparta.temueats.menu.controller;
 
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.menu.dto.MenuCreateDto;
+import com.sparta.temueats.menu.dto.MenuCreateWithImageDto;
 import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.dto.MenuUpdateDto;
 import com.sparta.temueats.menu.service.MenuService;
+import com.sparta.temueats.store.dto.StoreReqCreateWithImageDto;
+import com.sparta.temueats.store.dto.StoreReqResDto;
 import com.sparta.temueats.store.util.ValidUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -27,6 +30,16 @@ public class MenuController {
         ValidUtils.throwIfHasErrors(res, "메뉴 등록 실패");
 
         return menuService.save(menuCreateDto, req);
+    }
+
+    @PostMapping("/with-image")
+    public ResponseDto<MenuResDto> save(
+            @Valid @ModelAttribute MenuCreateWithImageDto menuCreateWithImageDto,
+            BindingResult res,
+            HttpServletRequest req) {
+        ValidUtils.throwIfHasErrors(res, "메뉴 등록 실패");
+
+        return menuService.save(menuCreateWithImageDto, req);
     }
 
     @PutMapping

--- a/src/main/java/com/sparta/temueats/menu/dto/MenuCreateWithImageDto.java
+++ b/src/main/java/com/sparta/temueats/menu/dto/MenuCreateWithImageDto.java
@@ -1,0 +1,58 @@
+package com.sparta.temueats.menu.dto;
+
+import com.sparta.temueats.menu.entity.Category;
+import com.sparta.temueats.menu.entity.P_menu;
+import com.sparta.temueats.store.entity.P_store;
+import com.sparta.temueats.store.entity.SellState;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class MenuCreateWithImageDto {
+
+    private UUID storeId;
+
+    @NotEmpty(message = "메뉴 이름은 필수입니다.")
+    private String name;
+
+    private String description;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
+    private Integer price;
+
+    private MultipartFile image;
+
+    @NotNull(message = "카테고리는 필수입니다.")
+    private Category category;
+
+    private SellState sellState;
+
+    @NotNull(message = "대표메뉴 여부는 필수입니다.")
+    private Boolean signatureYn;
+
+    public P_menu toEntity(P_store store, String image) {
+        return P_menu.builder()
+                .store(store)
+                .name(name)
+                .description(description)
+                .price(price)
+                .image(image)
+                .category(category)
+                .signatureYn(signatureYn)
+                .sellState(SellState.SALE)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/menu/dto/MenuUpdateDto.java
+++ b/src/main/java/com/sparta/temueats/menu/dto/MenuUpdateDto.java
@@ -35,17 +35,4 @@ public class MenuUpdateDto {
 
     private Boolean signatureYn;
 
-    public P_menu toEntity(P_store store) {
-        return P_menu.builder()
-                .store(store)
-                .name(this.name)
-                .description(this.description)
-                .price(this.price)
-                .image(this.image)
-                .category(this.category)
-                .signatureYn(this.signatureYn)
-                .sellState(SellState.SALE)
-                .build();
-    }
-
 }

--- a/src/main/java/com/sparta/temueats/menu/entity/P_menu.java
+++ b/src/main/java/com/sparta/temueats/menu/entity/P_menu.java
@@ -1,7 +1,6 @@
 package com.sparta.temueats.menu.entity;
 
 import com.sparta.temueats.global.BaseEntity;
-import com.sparta.temueats.menu.dto.MenuCreateDto;
 import com.sparta.temueats.menu.dto.MenuUpdateDto;
 import com.sparta.temueats.store.entity.P_store;
 import com.sparta.temueats.store.entity.SellState;

--- a/src/main/java/com/sparta/temueats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/temueats/menu/repository/MenuRepository.java
@@ -1,9 +1,11 @@
 package com.sparta.temueats.menu.repository;
 
 import com.sparta.temueats.menu.entity.P_menu;
+import com.sparta.temueats.store.entity.P_store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,5 +13,7 @@ import java.util.UUID;
 public interface MenuRepository extends JpaRepository<P_menu, UUID> {
 
     Optional<P_menu> findByName(String name);
-    
+
+    List<P_menu> findByStore(P_store store);
+
 }

--- a/src/main/java/com/sparta/temueats/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/temueats/menu/service/MenuService.java
@@ -7,6 +7,7 @@ import com.sparta.temueats.menu.dto.MenuUpdateDto;
 import com.sparta.temueats.menu.entity.P_menu;
 import com.sparta.temueats.menu.repository.MenuRepository;
 import com.sparta.temueats.store.entity.P_store;
+import com.sparta.temueats.store.repository.StoreRepository;
 import com.sparta.temueats.store.service.StoreService;
 import com.sparta.temueats.user.entity.P_user;
 import com.sparta.temueats.user.service.UserService;
@@ -26,7 +27,7 @@ import static com.sparta.temueats.global.ResponseDto.SUCCESS;
 public class MenuService {
 
     private final MenuRepository menuRepository;
-    private final StoreService storeService;
+    private final StoreRepository storeRepository;
     private final UserService userService;
 
     public ResponseDto<MenuResDto> save(MenuCreateDto menuCreateDto, HttpServletRequest req) {
@@ -35,7 +36,7 @@ public class MenuService {
             return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
         }
 
-        Optional<P_store> storeOptional = storeService.findById(menuCreateDto.getStoreId());
+        Optional<P_store> storeOptional = storeRepository.findById(menuCreateDto.getStoreId());
         if (storeOptional.isEmpty()) {
             return new ResponseDto<>(FAILURE, "유효하지 않은 가게 번호입니다.");
         }

--- a/src/main/java/com/sparta/temueats/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/temueats/menu/service/MenuService.java
@@ -1,14 +1,15 @@
 package com.sparta.temueats.menu.service;
 
 import com.sparta.temueats.global.ResponseDto;
+import com.sparta.temueats.s3.service.FileService;
 import com.sparta.temueats.menu.dto.MenuCreateDto;
+import com.sparta.temueats.menu.dto.MenuCreateWithImageDto;
 import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.dto.MenuUpdateDto;
 import com.sparta.temueats.menu.entity.P_menu;
 import com.sparta.temueats.menu.repository.MenuRepository;
 import com.sparta.temueats.store.entity.P_store;
 import com.sparta.temueats.store.repository.StoreRepository;
-import com.sparta.temueats.store.service.StoreService;
 import com.sparta.temueats.user.entity.P_user;
 import com.sparta.temueats.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import static com.sparta.temueats.global.ResponseDto.FAILURE;
@@ -29,6 +31,7 @@ public class MenuService {
     private final MenuRepository menuRepository;
     private final StoreRepository storeRepository;
     private final UserService userService;
+    private final FileService fileService;
 
     public ResponseDto<MenuResDto> save(MenuCreateDto menuCreateDto, HttpServletRequest req) {
         Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
@@ -50,6 +53,37 @@ public class MenuService {
         menuRepository.save(menu);
         return new ResponseDto<>(SUCCESS,"메뉴 등록 성공", new MenuResDto(menu));
     }
+
+    public ResponseDto<MenuResDto> save(MenuCreateWithImageDto menuCreateWithImageDto, HttpServletRequest req) {
+        Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
+        if (userOptional.isEmpty()) {
+            return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
+        }
+
+        Optional<P_store> storeOptional = storeRepository.findById(menuCreateWithImageDto.getStoreId());
+        if (storeOptional.isEmpty()) {
+            return new ResponseDto<>(FAILURE, "유효하지 않은 가게 번호입니다.");
+        }
+
+        if (menuRepository.findByName(menuCreateWithImageDto.getName()).isPresent()) {
+            return new ResponseDto<>(FAILURE, "이미 존재하는 메뉴입니다.");
+        }
+
+        String image = null;
+        if (menuCreateWithImageDto.getImage() != null && !menuCreateWithImageDto.getImage().isEmpty()) {
+            try {
+                image = fileService.uploadFile(menuCreateWithImageDto.getImage());
+            } catch (IOException e) {
+                return new ResponseDto<>(ResponseDto.FAILURE, "이미지 업로드 실패");
+            }
+        }
+
+        P_menu menu = menuCreateWithImageDto.toEntity(storeOptional.get(), image);
+        menu.setCreatedBy(userOptional.get().getNickname());
+        menuRepository.save(menu);
+        return new ResponseDto<>(SUCCESS,"메뉴 등록 성공", new MenuResDto(menu));
+    }
+
 
     public ResponseDto<MenuResDto> update(MenuUpdateDto menuUpdateDto, HttpServletRequest req) {
         Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);

--- a/src/main/java/com/sparta/temueats/rating/repository/RatingRepository.java
+++ b/src/main/java/com/sparta/temueats/rating/repository/RatingRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.temueats.rating.repository;
+
+import com.sparta.temueats.rating.entity.P_rating;
+import com.sparta.temueats.store.entity.P_store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RatingRepository extends JpaRepository<P_rating, UUID> {
+
+    P_rating findByStoreAndVisibleYn(P_store store, boolean visibleYn);
+
+}

--- a/src/main/java/com/sparta/temueats/review/dto/response/ReviewResDto.java
+++ b/src/main/java/com/sparta/temueats/review/dto/response/ReviewResDto.java
@@ -1,0 +1,27 @@
+package com.sparta.temueats.review.dto.response;
+
+import com.sparta.temueats.review.entity.P_review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class ReviewResDto {
+
+    private UUID reviewId;
+    private String content;
+    private int score;
+
+    public ReviewResDto(P_review pReview) {
+        this.reviewId = pReview.getReviewId();
+        this.content = pReview.getContent();
+        this.score = pReview.getScore();
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/review/entity/P_reviewComment.java
+++ b/src/main/java/com/sparta/temueats/review/entity/P_reviewComment.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "P_REVIEWCOMMENT")
+@Table(name = "P_REVIEW_COMMENT")
 public class P_reviewComment {
     @Id
     @GeneratedValue(generator = "UUID")

--- a/src/main/java/com/sparta/temueats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/temueats/review/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import com.sparta.temueats.store.entity.P_store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<P_review, UUID> {
@@ -13,5 +14,8 @@ public interface ReviewRepository extends JpaRepository<P_review, UUID> {
 
     @Query("SELECT COUNT(r) FROM P_review r WHERE r.store.storeId = :storeId AND r.useYn = true")
     Integer countReviewsByStoreId(UUID storeId);
+
+    @Query("SELECT r FROM P_review r WHERE r.store.storeId = :storeId AND r.useYn = true")
+    List<P_review> findByStoreId(UUID storeId);
 
 }

--- a/src/main/java/com/sparta/temueats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/temueats/review/repository/ReviewRepository.java
@@ -3,10 +3,15 @@ package com.sparta.temueats.review.repository;
 import com.sparta.temueats.review.entity.P_review;
 import com.sparta.temueats.store.entity.P_store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<P_review, UUID> {
 
 //    P_store findByStore(Long storeId);
+
+    @Query("SELECT COUNT(r) FROM P_review r WHERE r.store.storeId = :storeId AND r.useYn = true")
+    Integer countReviewsByStoreId(UUID storeId);
+
 }

--- a/src/main/java/com/sparta/temueats/s3/config/S3Config.java
+++ b/src/main/java/com/sparta/temueats/s3/config/S3Config.java
@@ -1,18 +1,16 @@
-package com.sparta.temueats.global.s3;
+package com.sparta.temueats.s3.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
+   /* @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
 
     @Value("${cloud.aws.credentials.secret-key}")
@@ -24,8 +22,19 @@ public class S3Config {
     @Bean
     public AmazonS3Client amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
         return (AmazonS3Client)AmazonS3ClientBuilder.standard()
                 .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }*/
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials("foo", "bar");
+
+        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+                .withRegion("baz")
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .build();
     }

--- a/src/main/java/com/sparta/temueats/s3/controller/FileController.java
+++ b/src/main/java/com/sparta/temueats/s3/controller/FileController.java
@@ -1,6 +1,7 @@
-package com.sparta.temueats.global.s3;
+package com.sparta.temueats.s3.controller;
 
 import com.sparta.temueats.global.ResponseDto;
+import com.sparta.temueats.s3.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/sparta/temueats/s3/service/FileService.java
+++ b/src/main/java/com/sparta/temueats/s3/service/FileService.java
@@ -1,9 +1,8 @@
-package com.sparta.temueats.global.s3;
+package com.sparta.temueats.s3.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,7 +15,7 @@ public class FileService {
 
     private final AmazonS3Client amazonS3Client;
 
-    @Value("${cloud.aws.s3.bucket}")
+//    @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
     public String uploadFile(MultipartFile file) throws IOException {

--- a/src/main/java/com/sparta/temueats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/temueats/store/controller/StoreController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+import static com.sparta.temueats.global.ResponseDto.FAILURE;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/stores")
@@ -35,10 +37,22 @@ public class StoreController {
 
     @GetMapping
     public ResponseDto<List<StoreResDto>> findByNameContaining(
-            @RequestParam String name,
+            @RequestParam(required = false) String store,
+            @RequestParam(required = false) String menu,
             HttpServletRequest req) {
-        return storeService.findByNameContaining(name, req);
+
+        if (store != null && !store.trim().isEmpty()) {
+            return storeService.findByStoreNameContaining(store, req);
+        }
+
+        if (menu != null && !menu.trim().isEmpty()) {
+            return storeService.findByMenuNameContaining(menu, req);
+        }
+
+        return new ResponseDto<>(FAILURE, "검색어는 필수입니다.");
     }
+
+
 
     @GetMapping("/{storeId}")
     public ResponseDto<StoreDetailResDto> findDetailById(@PathVariable UUID storeId, HttpServletRequest req) {

--- a/src/main/java/com/sparta/temueats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/temueats/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.sparta.temueats.store.controller;
 
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.store.dto.AddFavStoreRequestDto;
+import com.sparta.temueats.store.dto.StoreDetailResDto;
 import com.sparta.temueats.store.dto.StoreResDto;
 import com.sparta.temueats.store.dto.StoreUpdateDto;
 import com.sparta.temueats.store.service.StoreService;
@@ -13,6 +14,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,8 +34,13 @@ public class StoreController {
     }
 
     @GetMapping
-    public ResponseDto<List<StoreResDto>> findByName(@RequestParam String name) {
-        return storeService.findByName(name);
+    public ResponseDto<List<StoreResDto>> findByNameContaining(@RequestParam String name) {
+        return storeService.findByNameContaining(name);
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseDto<StoreDetailResDto> findDetailById(@PathVariable UUID storeId, HttpServletRequest req) {
+        return storeService.findDetailById(storeId, req);
     }
 
     // 즐겨찾기 추가, 삭제

--- a/src/main/java/com/sparta/temueats/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/temueats/store/controller/StoreController.java
@@ -34,8 +34,10 @@ public class StoreController {
     }
 
     @GetMapping
-    public ResponseDto<List<StoreResDto>> findByNameContaining(@RequestParam String name) {
-        return storeService.findByNameContaining(name);
+    public ResponseDto<List<StoreResDto>> findByNameContaining(
+            @RequestParam String name,
+            HttpServletRequest req) {
+        return storeService.findByNameContaining(name, req);
     }
 
     @GetMapping("/{storeId}")

--- a/src/main/java/com/sparta/temueats/store/controller/StoreReqController.java
+++ b/src/main/java/com/sparta/temueats/store/controller/StoreReqController.java
@@ -31,7 +31,7 @@ public class StoreReqController {
     }
     
     @PostMapping("/with-image")
-    public ResponseDto<StoreReqResDto> saveWithImage(
+    public ResponseDto<StoreReqResDto> save(
             @Valid @ModelAttribute StoreReqCreateWithImageDto storeReqCreateWithImageDto,
             BindingResult res,
             HttpServletRequest req) {

--- a/src/main/java/com/sparta/temueats/store/controller/StoreReqController.java
+++ b/src/main/java/com/sparta/temueats/store/controller/StoreReqController.java
@@ -2,6 +2,7 @@ package com.sparta.temueats.store.controller;
 
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.store.dto.StoreReqCreateDto;
+import com.sparta.temueats.store.dto.StoreReqCreateWithImageDto;
 import com.sparta.temueats.store.dto.StoreReqResDto;
 import com.sparta.temueats.store.dto.StoreReqUpdateDto;
 import com.sparta.temueats.store.service.StoreReqService;
@@ -27,6 +28,16 @@ public class StoreReqController {
         ValidUtils.throwIfHasErrors(res, "가게 등록 요청 실패");
 
         return storeReqService.save(storeReqCreateDto, req);
+    }
+    
+    @PostMapping("/with-image")
+    public ResponseDto<StoreReqResDto> saveWithImage(
+            @Valid @ModelAttribute StoreReqCreateWithImageDto storeReqCreateWithImageDto,
+            BindingResult res,
+            HttpServletRequest req) {
+        ValidUtils.throwIfHasErrors(res, "가게 등록 요청 실패");
+
+        return storeReqService.save(storeReqCreateWithImageDto, req);
     }
 
     @PutMapping

--- a/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
@@ -1,0 +1,67 @@
+package com.sparta.temueats.store.dto;
+
+import com.sparta.temueats.menu.dto.MenuResDto;
+import com.sparta.temueats.menu.entity.Category;
+import com.sparta.temueats.store.entity.P_store;
+import com.sparta.temueats.store.entity.StoreState;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class StoreDetailResDto {
+
+    private String storeId;
+    private String name;
+    private String image;
+    private String number;
+    private StoreState state;
+    private Integer leastPrice;
+    private Integer deliveryPrice;
+    private Category category;
+    private Double latitude;
+    private Double longitude;
+    private String address;
+    private Double rating;
+    private Integer reviewCount;
+    private Boolean isFavorite;
+    private List<MenuResDto> menu;
+
+    public StoreDetailResDto(P_store store) {
+        storeId = store.getStoreId().toString();
+        name = store.getName();
+        image = store.getImage();
+        number = store.getNumber();
+        state = store.getState();
+        leastPrice = store.getLeastPrice();
+        deliveryPrice = store.getDeliveryPrice();
+        category = store.getCategory();
+        latitude = store.getLatLng().getX();
+        longitude = store.getLatLng().getY();
+        address = store.getAddress();
+    }
+
+    public StoreDetailResDto(P_store store, Double rating, Integer reviewCount, Boolean isFavorite) {
+        storeId = store.getStoreId().toString();
+        name = store.getName();
+        image = store.getImage();
+        number = store.getNumber();
+        state = store.getState();
+        leastPrice = store.getLeastPrice();
+        deliveryPrice = store.getDeliveryPrice();
+        category = store.getCategory();
+        latitude = store.getLatLng().getX();
+        longitude = store.getLatLng().getY();
+        address = store.getAddress();
+        this.rating = rating;
+        this.reviewCount = reviewCount;
+        this.isFavorite = isFavorite;
+    }
+
+}

--- a/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
@@ -2,6 +2,7 @@ package com.sparta.temueats.store.dto;
 
 import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.entity.Category;
+import com.sparta.temueats.review.dto.response.ReviewResDto;
 import com.sparta.temueats.store.entity.P_store;
 import com.sparta.temueats.store.entity.StoreState;
 import lombok.AllArgsConstructor;
@@ -32,6 +33,7 @@ public class StoreDetailResDto {
     private Integer reviewCount;
     private Boolean isFavorite;
     private List<MenuResDto> menu;
+    private List<ReviewResDto> reviews;
 
     public StoreDetailResDto(P_store store) {
         storeId = store.getStoreId().toString();

--- a/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreDetailResDto.java
@@ -47,21 +47,4 @@ public class StoreDetailResDto {
         address = store.getAddress();
     }
 
-    public StoreDetailResDto(P_store store, Double rating, Integer reviewCount, Boolean isFavorite) {
-        storeId = store.getStoreId().toString();
-        name = store.getName();
-        image = store.getImage();
-        number = store.getNumber();
-        state = store.getState();
-        leastPrice = store.getLeastPrice();
-        deliveryPrice = store.getDeliveryPrice();
-        category = store.getCategory();
-        latitude = store.getLatLng().getX();
-        longitude = store.getLatLng().getY();
-        address = store.getAddress();
-        this.rating = rating;
-        this.reviewCount = reviewCount;
-        this.isFavorite = isFavorite;
-    }
-
 }

--- a/src/main/java/com/sparta/temueats/store/dto/StoreReqCreateDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreReqCreateDto.java
@@ -50,18 +50,6 @@ public class StoreReqCreateDto {
     @Size(max = 50, message = "주소는 최대 50자입니다.")
     private String address;
 
-    public StoreReqCreateDto(P_storeReq storeReq) {
-        this.name = storeReq.getName();
-        this.image = storeReq.getImage();
-        this.number = storeReq.getNumber();
-        this.leastPrice = storeReq.getLeastPrice();
-        this.deliveryPrice = storeReq.getDeliveryPrice();
-        this.category = storeReq.getCategory();
-        this.latitude = storeReq.getLatLng().getX();
-        this.longitude = storeReq.getLatLng().getY();
-        this.address = storeReq.getAddress();
-    }
-
     public P_storeReq toEntity(P_user user) {
         return P_storeReq.builder()
                 .requestedBy(user)

--- a/src/main/java/com/sparta/temueats/store/dto/StoreReqCreateWithImageDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreReqCreateWithImageDto.java
@@ -13,19 +13,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-public class StoreReqCreateDto {
+public class StoreReqCreateWithImageDto {
 
     @NotBlank(message = "가게 이름은 필수입니다.")
     @Size(min = 2, max = 50, message = "가게 이름은 2자 이상 50자 이하로 입력해주세요.")
     private String name;
 
-    @Size(max = 500, message = "이미지 URL은 최대 500자입니다.")
-    private String image;
+    private MultipartFile image;
 
     @NotBlank(message = "전화번호는 필수입니다.")
     @Size(min = 10, max = 15, message = "전화번호는 최소 10자 이상, 15자 이하로 입력해주세요.")
@@ -50,7 +50,7 @@ public class StoreReqCreateDto {
     @Size(max = 50, message = "주소는 최대 50자입니다.")
     private String address;
 
-    public P_storeReq toEntity(P_user user) {
+    public P_storeReq toEntity(P_user user, String image) {
         return P_storeReq.builder()
                 .requestedBy(user)
                 .name(name)

--- a/src/main/java/com/sparta/temueats/store/dto/StoreResDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreResDto.java
@@ -29,7 +29,7 @@ public class StoreResDto {
     private Integer reviewCount;
     private Boolean isFavorite;
 
-    public StoreResDto(P_store store, Double rating, Integer reviewCount) {
+    public StoreResDto(P_store store, Double rating, Integer reviewCount, Boolean isFavorite) {
         storeId = store.getStoreId().toString();
         name = store.getName();
         image = store.getImage();
@@ -43,6 +43,7 @@ public class StoreResDto {
         address = store.getAddress();
         this.rating = rating;
         this.reviewCount = reviewCount;
+        this.isFavorite = isFavorite;
     }
 
     public StoreResDto(P_store store) {

--- a/src/main/java/com/sparta/temueats/store/dto/StoreResDto.java
+++ b/src/main/java/com/sparta/temueats/store/dto/StoreResDto.java
@@ -1,6 +1,5 @@
 package com.sparta.temueats.store.dto;
 
-import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.entity.Category;
 import com.sparta.temueats.store.entity.P_store;
 import com.sparta.temueats.store.entity.StoreState;
@@ -8,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -31,7 +28,6 @@ public class StoreResDto {
     private Double rating;
     private Integer reviewCount;
     private Boolean isFavorite;
-    private List<MenuResDto> menu;
 
     public StoreResDto(P_store store, Double rating, Integer reviewCount) {
         storeId = store.getStoreId().toString();

--- a/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
@@ -19,9 +19,21 @@ public interface StoreRepository extends JpaRepository<P_store, UUID> {
            "FROM P_STORE s " +
            "LEFT JOIN P_review rv ON rv.store = s " +
            "LEFT JOIN P_RATING r ON r.store = s " +
-           "WHERE s.name LIKE %:name% " +
+           "WHERE s.name LIKE %:storeName% " +
            "GROUP BY s")
-    List<StoreResDto> findByNameContaining(String name, Long userId);
+    List<StoreResDto> findByStoreNameContaining(String storeName, Long userId);
+
+    @Query("SELECT new com.sparta.temueats.store.dto.StoreResDto(s, " +
+            "COALESCE(AVG(r.score), 0), " +
+            "CAST(COUNT(rv) AS INTEGER), " +
+            "(CASE WHEN EXISTS (SELECT 1 FROM P_FAV_STORE f WHERE f.user.id = :userId AND f.store = s) THEN true ELSE false END)) " +
+            "FROM P_STORE s " +
+            "LEFT JOIN P_review rv ON rv.store = s " +
+            "LEFT JOIN P_RATING r ON r.store = s " +
+            "LEFT JOIN P_MENU m ON m.store = s " +
+            "WHERE m.name LIKE %:menuName% " +
+            "GROUP BY s")
+    List<StoreResDto> findByMenuNameContaining(String menuName, Long userId);
 
     List<P_store> findByName(String name);
 

--- a/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
@@ -1,30 +1,27 @@
 package com.sparta.temueats.store.repository;
 
-import com.sparta.temueats.store.dto.StoreDetailResDto;
 import com.sparta.temueats.store.dto.StoreResDto;
 import com.sparta.temueats.store.entity.P_store;
-import com.sparta.temueats.user.entity.P_user;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface StoreRepository extends JpaRepository<P_store, UUID> {
 
-    @Query("SELECT new com.sparta.temueats.store.dto.StoreResDto(s, " +
-            "COALESCE(AVG(r.score), 0), " +
-            "CAST(COUNT(rv) AS INTEGER)) " +
-            "FROM P_STORE s " +
-            "LEFT JOIN P_review rv ON rv.store = s " +
-            "LEFT JOIN P_RATING r ON r.store = s " +
-            "WHERE s.name LIKE %:name% " +
-            "GROUP BY s")
-    List<StoreResDto> findByNameContaining(String name);
+   @Query("SELECT new com.sparta.temueats.store.dto.StoreResDto(s, " +
+           "COALESCE(AVG(r.score), 0), " +
+           "CAST(COUNT(rv) AS INTEGER), " +
+           "(CASE WHEN EXISTS (SELECT 1 FROM P_FAV_STORE f WHERE f.user.id = :userId AND f.store = s) THEN true ELSE false END)) " +
+           "FROM P_STORE s " +
+           "LEFT JOIN P_review rv ON rv.store = s " +
+           "LEFT JOIN P_RATING r ON r.store = s " +
+           "WHERE s.name LIKE %:name% " +
+           "GROUP BY s")
+    List<StoreResDto> findByNameContaining(String name, Long userId);
 
     List<P_store> findByName(String name);
 

--- a/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/temueats/store/repository/StoreRepository.java
@@ -1,12 +1,16 @@
 package com.sparta.temueats.store.repository;
 
+import com.sparta.temueats.store.dto.StoreDetailResDto;
 import com.sparta.temueats.store.dto.StoreResDto;
 import com.sparta.temueats.store.entity.P_store;
+import com.sparta.temueats.user.entity.P_user;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository

--- a/src/main/java/com/sparta/temueats/store/service/StoreReqService.java
+++ b/src/main/java/com/sparta/temueats/store/service/StoreReqService.java
@@ -1,7 +1,9 @@
 package com.sparta.temueats.store.service;
 
 import com.sparta.temueats.global.ResponseDto;
+import com.sparta.temueats.global.s3.FileService;
 import com.sparta.temueats.store.dto.StoreReqCreateDto;
+import com.sparta.temueats.store.dto.StoreReqCreateWithImageDto;
 import com.sparta.temueats.store.dto.StoreReqResDto;
 import com.sparta.temueats.store.dto.StoreReqUpdateDto;
 import com.sparta.temueats.store.entity.P_store;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import static com.sparta.temueats.global.ResponseDto.FAILURE;
@@ -29,6 +32,7 @@ public class StoreReqService {
     private final StoreReqRepository storeReqRepository;
     private final StoreRepository storeRepository;
     private final UserService userService;
+    private final FileService fileService;
 
     public ResponseDto<StoreReqResDto> save(StoreReqCreateDto storeReqCreateDto, HttpServletRequest req) {
         Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
@@ -45,6 +49,28 @@ public class StoreReqService {
         storeReq.setCreatedBy(user.getNickname());
         storeReqRepository.save(storeReq);
         return new ResponseDto<>(SUCCESS, "가게 등록 요청 성공", new StoreReqResDto(storeReq));
+    }
+
+    public ResponseDto<StoreReqResDto> save(
+            StoreReqCreateWithImageDto storeReqCreateWithImageDto,
+            HttpServletRequest req) {
+        Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
+        if (userOptional.isEmpty()) {
+            return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
+        }
+
+        String image = null;
+        if (storeReqCreateWithImageDto.getImage() != null && !storeReqCreateWithImageDto.getImage().isEmpty()) {
+            try {
+                image = fileService.uploadFile(storeReqCreateWithImageDto.getImage());
+            } catch (IOException e) {
+                return new ResponseDto<>(ResponseDto.FAILURE, "이미지 업로드 실패");
+            }
+        }
+
+        P_storeReq storeReq = storeReqCreateWithImageDto.toEntity(userOptional.get(), image);
+        StoreReqResDto storeReqResDto = new StoreReqResDto(storeReqRepository.save(storeReq));
+        return new ResponseDto<>(SUCCESS, "가게 등록 요청 성공", storeReqResDto);
     }
 
     public ResponseDto<Object> update(StoreReqUpdateDto storeReqUpdateDto, HttpServletRequest req) {

--- a/src/main/java/com/sparta/temueats/store/service/StoreReqService.java
+++ b/src/main/java/com/sparta/temueats/store/service/StoreReqService.java
@@ -1,7 +1,7 @@
 package com.sparta.temueats.store.service;
 
 import com.sparta.temueats.global.ResponseDto;
-import com.sparta.temueats.global.s3.FileService;
+import com.sparta.temueats.s3.service.FileService;
 import com.sparta.temueats.store.dto.StoreReqCreateDto;
 import com.sparta.temueats.store.dto.StoreReqCreateWithImageDto;
 import com.sparta.temueats.store.dto.StoreReqResDto;
@@ -59,6 +59,10 @@ public class StoreReqService {
             return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
         }
 
+        if (!storeRepository.findByName(storeReqCreateWithImageDto.getName()).isEmpty()) {
+            return new ResponseDto<>(FAILURE, "이미 존재하는 가게명입니다.");
+        }
+
         String image = null;
         if (storeReqCreateWithImageDto.getImage() != null && !storeReqCreateWithImageDto.getImage().isEmpty()) {
             try {
@@ -68,7 +72,9 @@ public class StoreReqService {
             }
         }
 
-        P_storeReq storeReq = storeReqCreateWithImageDto.toEntity(userOptional.get(), image);
+        P_user user = userOptional.get();
+        P_storeReq storeReq = storeReqCreateWithImageDto.toEntity(user, image);
+        storeReq.setCreatedBy(user.getNickname());
         StoreReqResDto storeReqResDto = new StoreReqResDto(storeReqRepository.save(storeReq));
         return new ResponseDto<>(SUCCESS, "가게 등록 요청 성공", storeReqResDto);
     }

--- a/src/main/java/com/sparta/temueats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/temueats/store/service/StoreService.java
@@ -55,12 +55,17 @@ public class StoreService {
         return new ResponseDto<>(SUCCESS, "가게 정보 수정 성공");
     }
 
-    public ResponseDto<List<StoreResDto>> findByNameContaining(String name) {
+    public ResponseDto<List<StoreResDto>> findByNameContaining(String name, HttpServletRequest req) {
+        Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
+        if (userOptional.isEmpty()) {
+            return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
+        }
+
         if (name == null || name.trim().isEmpty()) {
             return new ResponseDto<>(FAILURE, "검색어는 필수입니다.");
         }
 
-        List<StoreResDto> stores = storeRepository.findByNameContaining(name);
+        List<StoreResDto> stores = storeRepository.findByNameContaining(name, userOptional.get().getId());
 
         if (stores.isEmpty()) {
             return new ResponseDto<>(SUCCESS, name + "와(과) 일치하는 검색결과가 없습니다.");

--- a/src/main/java/com/sparta/temueats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/temueats/store/service/StoreService.java
@@ -2,9 +2,11 @@ package com.sparta.temueats.store.service;
 
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.menu.dto.MenuResDto;
-import com.sparta.temueats.menu.entity.P_menu;
 import com.sparta.temueats.menu.repository.MenuRepository;
 import com.sparta.temueats.menu.service.MenuService;
+import com.sparta.temueats.rating.repository.RatingRepository;
+import com.sparta.temueats.review.dto.response.ReviewResDto;
+import com.sparta.temueats.review.entity.P_review;
 import com.sparta.temueats.review.repository.ReviewRepository;
 import com.sparta.temueats.store.dto.*;
 import com.sparta.temueats.store.entity.P_favStore;
@@ -35,7 +37,7 @@ public class StoreService {
     private final UserService userService;
     private final ReviewRepository reviewRepository;
     private final MenuRepository menuRepository;
-    private final MenuService menuService;
+    private final RatingRepository ratingRepository;
 
     public ResponseDto<Object> update(StoreUpdateDto storeUpdateDto, HttpServletRequest req) {
         Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
@@ -86,10 +88,12 @@ public class StoreService {
         P_store store = storeOptional.get();
 
         StoreDetailResDto storeDetailResDto = new StoreDetailResDto(store);
-        storeDetailResDto.setReviewCount(reviewRepository.countReviewsByStoreId(storeId));
+        List<P_review> reviews = reviewRepository.findByStoreId(storeId);
+        storeDetailResDto.setReviewCount(reviews.size());
         storeDetailResDto.setIsFavorite(favStoreRepository.findByUserAndStore(user, store).isPresent());
         storeDetailResDto.setMenu(menuRepository.findByStore(store).stream().map(MenuResDto::new).toList());
-
+        storeDetailResDto.setReviews(reviews.stream().map(ReviewResDto::new).toList());
+        storeDetailResDto.setRating(ratingRepository.findByStoreAndVisibleYn(store, true).getScore());
         return new ResponseDto<>(SUCCESS, "가게 상세 조회 성공", storeDetailResDto);
     }
 

--- a/src/main/java/com/sparta/temueats/store/service/StoreService.java
+++ b/src/main/java/com/sparta/temueats/store/service/StoreService.java
@@ -3,7 +3,6 @@ package com.sparta.temueats.store.service;
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.menu.dto.MenuResDto;
 import com.sparta.temueats.menu.repository.MenuRepository;
-import com.sparta.temueats.menu.service.MenuService;
 import com.sparta.temueats.rating.repository.RatingRepository;
 import com.sparta.temueats.review.dto.response.ReviewResDto;
 import com.sparta.temueats.review.entity.P_review;
@@ -55,20 +54,31 @@ public class StoreService {
         return new ResponseDto<>(SUCCESS, "가게 정보 수정 성공");
     }
 
-    public ResponseDto<List<StoreResDto>> findByNameContaining(String name, HttpServletRequest req) {
+    public ResponseDto<List<StoreResDto>> findByStoreNameContaining(String storeName, HttpServletRequest req) {
         Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
         if (userOptional.isEmpty()) {
             return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
         }
 
-        if (name == null || name.trim().isEmpty()) {
-            return new ResponseDto<>(FAILURE, "검색어는 필수입니다.");
-        }
-
-        List<StoreResDto> stores = storeRepository.findByNameContaining(name, userOptional.get().getId());
+        List<StoreResDto> stores = storeRepository.findByStoreNameContaining(storeName, userOptional.get().getId());
 
         if (stores.isEmpty()) {
-            return new ResponseDto<>(SUCCESS, name + "와(과) 일치하는 검색결과가 없습니다.");
+            return new ResponseDto<>(SUCCESS, storeName + "와(과) 일치하는 검색결과가 없습니다.");
+        }
+
+        return new ResponseDto<>(SUCCESS, "가게 검색 성공", stores);
+    }
+
+    public ResponseDto<List<StoreResDto>> findByMenuNameContaining(String menuName, HttpServletRequest req) {
+        Optional<P_user> userOptional = userService.validateTokenAndGetUser(req);
+        if (userOptional.isEmpty()) {
+            return new ResponseDto<>(FAILURE, "유효하지 않은 토큰이거나 존재하지 않는 사용자입니다.");
+        }
+
+        List<StoreResDto> stores = storeRepository.findByMenuNameContaining(menuName, userOptional.get().getId());
+
+        if (stores.isEmpty()) {
+            return new ResponseDto<>(SUCCESS, menuName + "와(과) 일치하는 검색결과가 없습니다.");
         }
 
         return new ResponseDto<>(SUCCESS, "가게 검색 성공", stores);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: temueats
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/temueats
+    url: jdbc:postgresql://13.125.168.6:5432/temueats
     username:
     password:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## Subject
가게 상세 조회 기능 및 파일 업로드 API 구현

## Content
- ReviewRepository에 countReviewsByStoreId 메서드 추가
- 가게 자체 정보 외 해당 가게의 메뉴 목록, 평점, 리뷰 수, 즐겨찾기 여부 조회
- GlobalExceptionHandler 추가
- 파일 업로드 API 구현
- 가게 등록 요청 및 메뉴 등록 요청 시 이미지 파일 입력받아 DB 저장
- 메뉴로 가게 검색 기능 구현

## Footer
resolves : #16 #49 #78 #79 #20 
