### PR TITLE
feat: 결제 후 결제 상태 수정 구현

### DIFF
--- a/src/main/java/com/sparta/temueats/payment/controller/PaymentController.java
+++ b/src/main/java/com/sparta/temueats/payment/controller/PaymentController.java
@@ -2,11 +2,11 @@ package com.sparta.temueats.payment.controller;
 
 import com.sparta.temueats.global.ResponseDto;
 import com.sparta.temueats.payment.dto.PaymentGetResponseDto;
+import com.sparta.temueats.payment.dto.PaymentModifyRequestDto;
 import com.sparta.temueats.payment.service.PaymentService;
 import com.sparta.temueats.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -28,5 +28,12 @@ public class PaymentController {
     public ResponseDto<?> getPaymentResponseDto(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         PaymentGetResponseDto paymentGetResponseDto = paymentService.getPayments(userDetails.getUser());
         return new ResponseDto<>(1, "결제 조회에 성공했습니다.", paymentGetResponseDto);
+    }
+
+    @PutMapping("/payments/{paymentId}")
+    public ResponseDto<?> modifyPaymentResponseDto(@RequestBody PaymentModifyRequestDto paymentmodifyRequestDto,
+                                                   @PathVariable UUID paymentId) {
+        paymentService.modifyPayment(paymentmodifyRequestDto, paymentId);
+        return new ResponseDto<>(1, "결제가 완료되었습니다.", null);
     }
 }

--- a/src/main/java/com/sparta/temueats/payment/dto/PaymentModifyRequestDto.java
+++ b/src/main/java/com/sparta/temueats/payment/dto/PaymentModifyRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.temueats.payment.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+@Getter
+public class PaymentModifyRequestDto {
+
+    @Min(0)
+    @Max(1)
+    private int paymentStatus;
+
+}

--- a/src/main/java/com/sparta/temueats/payment/entity/P_payment.java
+++ b/src/main/java/com/sparta/temueats/payment/entity/P_payment.java
@@ -35,4 +35,8 @@ public class P_payment extends BaseEntity {
         this.price = price;
         this.order = order;
     }
+
+    public void setStatus(PaymentStatus paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
 }


### PR DESCRIPTION
## Subject
결제 후 결제 상태 수정 구현

## Content
- 외부에서 결제 여부를 1(성공) 0(실패)로 받아온다
- 결제가 성공하면 결제 상태를 PAID로 설정하고 orderService에 있는 주문 상태 변경 로직을 실행한다
- 결제가 실패하면 결제 상태를 FAIL로 설정하고 저장 후, 예외를 발생시킨다

## Footer
resolves : #109